### PR TITLE
Added mid_time() to FileMetadata  issue #53

### DIFF
--- a/sospice/catalog/file_metadata.py
+++ b/sospice/catalog/file_metadata.py
@@ -345,6 +345,23 @@ class FileMetadata:
         )
         return observer
 
+    def mid_time(self):
+        """
+        Find "middle time" for observation in FileMetaData
+
+        Return
+        ----------
+        pd.Timestamp
+            The middle time of the observation.
+        """
+        if self.metadata["DATE-BEG"] and self.metadata["TELAPSE"] :
+            date_beg = self.metadata["DATE-BEG"]
+            return date_beg + pd.Timedelta(seconds=self.metadata["TELAPSE"] / 2) 
+        else:
+            raise RuntimeError("FileMetaData not found")
+    
+
+
     def get_fov(self, points=None, method=None):
         """
         Get the FOV coordinates (bottom left and top right vertices of rectangle
@@ -438,3 +455,5 @@ class FileMetadata:
                     *text_args, **text_kwargs
                 )
                 ax.text(*text_args, **text_kwargs)
+
+

--- a/sospice/catalog/file_metadata.py
+++ b/sospice/catalog/file_metadata.py
@@ -354,11 +354,9 @@ class FileMetadata:
         pd.Timestamp
             The middle time of the observation.
         """
-        if self.metadata["DATE-BEG"] and self.metadata["TELAPSE"]:
-            date_beg = self.metadata["DATE-BEG"]
-            return date_beg + pd.Timedelta(seconds=self.metadata["TELAPSE"] / 2)
-        else:
-            raise RuntimeError("FileMetaData not found")
+
+        date_beg = self.metadata["DATE-BEG"]
+        return date_beg + pd.Timedelta(seconds=self.metadata["TELAPSE"] / 2)
 
     def get_fov(self, points=None, method=None):
         """

--- a/sospice/catalog/file_metadata.py
+++ b/sospice/catalog/file_metadata.py
@@ -354,13 +354,11 @@ class FileMetadata:
         pd.Timestamp
             The middle time of the observation.
         """
-        if self.metadata["DATE-BEG"] and self.metadata["TELAPSE"] :
+        if self.metadata["DATE-BEG"] and self.metadata["TELAPSE"]:
             date_beg = self.metadata["DATE-BEG"]
-            return date_beg + pd.Timedelta(seconds=self.metadata["TELAPSE"] / 2) 
+            return date_beg + pd.Timedelta(seconds=self.metadata["TELAPSE"] / 2)
         else:
             raise RuntimeError("FileMetaData not found")
-    
-
 
     def get_fov(self, points=None, method=None):
         """
@@ -455,5 +453,3 @@ class FileMetadata:
                     *text_args, **text_kwargs
                 )
                 ax.text(*text_args, **text_kwargs)
-
-

--- a/sospice/catalog/tests/test_file_metadata.py
+++ b/sospice/catalog/tests/test_file_metadata.py
@@ -115,17 +115,14 @@ class TestFileMetadata:
         assert u.isclose(observer.lon, -3.3713006 * u.deg)
         assert u.isclose(observer.lat, -4.2335761 * u.deg)
         assert u.isclose(observer.radius, 0.52286922 * u.au)
-    
+
     def test_file_mid_time(self, file_metadata):
         fm = file_metadata
         date_beg = fm.metadata["DATE-BEG"]
         telapse = fm.metadata["TELAPSE"]
         expected_mid_time = date_beg + pd.Timedelta(seconds=telapse / 2)
-        assert (
-            abs(fm.mid_time() - expected_mid_time).total_seconds()
-            < 1  # noqa: W503
-            )
-   
+        assert abs(fm.mid_time() - expected_mid_time).total_seconds() < 1  # noqa: W503
+
     def test_get_fov(self, file_metadata):
         observer = file_metadata.get_observer()
         frame = Helioprojective(observer=observer, obstime=observer.obstime)

--- a/sospice/catalog/tests/test_file_metadata.py
+++ b/sospice/catalog/tests/test_file_metadata.py
@@ -118,9 +118,7 @@ class TestFileMetadata:
 
     def test_file_mid_time(self, file_metadata):
         fm = file_metadata
-        date_beg = fm.metadata["DATE-BEG"]
-        telapse = fm.metadata["TELAPSE"]
-        expected_mid_time = date_beg + pd.Timedelta(seconds=telapse / 2)
+        expected_mid_time = pd.Timestamp("2022-03-05 07:25:52.038000")
         assert abs(fm.mid_time() - expected_mid_time).total_seconds() < 1  # noqa: W503
 
     def test_get_fov(self, file_metadata):

--- a/sospice/catalog/tests/test_file_metadata.py
+++ b/sospice/catalog/tests/test_file_metadata.py
@@ -115,7 +115,17 @@ class TestFileMetadata:
         assert u.isclose(observer.lon, -3.3713006 * u.deg)
         assert u.isclose(observer.lat, -4.2335761 * u.deg)
         assert u.isclose(observer.radius, 0.52286922 * u.au)
-
+    
+    def test_file_mid_time(self, file_metadata):
+        fm = file_metadata
+        date_beg = fm.metadata["DATE-BEG"]
+        telapse = fm.metadata["TELAPSE"]
+        expected_mid_time = date_beg + pd.Timedelta(seconds=telapse / 2)
+        assert (
+            abs(fm.mid_time() - expected_mid_time).total_seconds()
+            < 1  # noqa: W503
+            )
+   
     def test_get_fov(self, file_metadata):
         observer = file_metadata.get_observer()
         frame = Helioprojective(observer=observer, obstime=observer.obstime)


### PR DESCRIPTION
- mid_time() is now moved to FileMetadata class, calculated mid-range of file metadata.
- Test case for FileMetadata.mid_time() also added in test_file_metadata.py. 

ps: Thanks for the help, its a great project.